### PR TITLE
Update .stylelintrc

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,5 +2,5 @@
   "extends": [
     "stylelint-config-recommended"
   ],
-  "ignoreFiles": ["**/*.json", "**/*.png", "**/*.svg", "**/*.eot", "**/*.ttf", "**/*.woff", "**/*.woff2", "silta/*"]
+  "ignoreFiles": ["**/*.json", "**/*.ico", "**/*.png", "**/*.svg", "**/*.eot", "**/*.ttf", "**/*.woff", "**/*.woff2", "silta/*"]
 }


### PR DESCRIPTION
Favicons seems to cause false stylelint issues

```console
juhovaltonen@juho react-paragraphs-nextjs % npm run lint:style

> drupal-paragraphs-nextjs@0.1.0 lint:style /Users/juhovaltonen/Sites/react-paragraphs-nextjs
> stylelint ./


public/favicon.ico
 18:2683  ✖  Unclosed string   CssSyntaxError
```